### PR TITLE
install netbase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ MAINTAINER Roni Väyrynen <roni@vayrynen.info>
 # backports repo needed for monit
 RUN echo 'deb http://deb.debian.org/debian/ buster-backports main' | tee /etc/apt/sources.list.d/backports.list
 RUN apt update && \
-    apt install -y redis-server libvhdi-utils python2-minimal python-jinja2 lvm2 nfs-common cifs-utils ca-certificates monit procps curl
+    apt install -y redis-server libvhdi-utils python2-minimal python-jinja2 lvm2 nfs-common netbase cifs-utils ca-certificates monit procps curl
 
 # Install forever for starting/stopping Xen-Orchestra
 RUN npm install forever -g


### PR DESCRIPTION
`netbase` dpkg provides /etc/protocols used by /sbin/mount.nfs, otherwise NFS mounts will fail as follows:

Command failed with exit code 32: mount -o  -t nfs 192.168.1.2:/e/xo-backup /run/xo-server/mounts/4d2f84d0-35b5-404d-b5b3-fbe998fbbe71
mount.nfs: Protocol not supported

root@818a77161793:/# strace sbin/mount.nfs -v -o ro,nolock,vers=3 192.168.1.2:/e/xo-backup /mnt
...
openat(AT_FDCWD, "/etc/protocols", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
write(2, "mount.nfs: Protocol not supporte"..., 34mount.nfs: Protocol not supported
) = 34
...
exit_group(32)                          = ?
+++ exited with 32 +++