### PR TITLE
Use recommended versions (base/node/python) from upstream build instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
 # builder container
-FROM node:16-buster as build
+FROM node:18-bullseye as build
 
 # Install set of dependencies to support building Xen Orchestra
 RUN apt update && \
-    apt install -y build-essential python2-minimal libpng-dev ca-certificates git
+    apt install -y build-essential python3-minimal libpng-dev ca-certificates nfs-common ntfs-3g dmidecode
 
 # Fetch Xen-Orchestra sources from git stable branch
 RUN git clone -b master https://github.com/vatesfr/xen-orchestra /etc/xen-orchestra
+
+ENV PYTHON=/usr/bin/python3
+ENV npm_config_python=/usr/bin/python3
 
 # Run build tasks against sources
 # Docker buildx QEMU arm64 emulation is slow, so we set timeout for yarn
@@ -16,18 +19,21 @@ RUN cd /etc/xen-orchestra && \
     yarn build
 
 # Install plugins
-RUN find /etc/xen-orchestra/packages/ -maxdepth 1 -mindepth 1 -not -name "xo-server" -not -name "xo-web" -not -name "xo-server-cloud" -exec ln -s {} /etc/xen-orchestra/packages/xo-server/node_modules \;
+RUN find /etc/xen-orchestra/packages/ -maxdepth 1 -mindepth 1 -not -name "xo-server" -not -name "xo-web" -not -name "xo-server-cloud" -not -name "xo-server-test" -not -name "xo-server-test-plugin" -exec ln -s {} /etc/xen-orchestra/packages/xo-server/node_modules \;
 
 # Runner container
-FROM node:16-buster-slim
+FROM node:18-bullseye-slim
 
 MAINTAINER Roni Väyrynen <roni@vayrynen.info>
 
+ENV PYTHON=/usr/bin/python3
+ENV npm_config_python=/usr/bin/python3
+
 # Install set of dependencies for running Xen Orchestra
 # backports repo needed for monit
-RUN echo 'deb http://deb.debian.org/debian/ buster-backports main' | tee /etc/apt/sources.list.d/backports.list
+RUN echo 'deb http://deb.debian.org/debian/ bullseye-backports main' | tee /etc/apt/sources.list.d/backports.list
 RUN apt update && \
-    apt install -y redis-server libvhdi-utils python2-minimal python-jinja2 lvm2 nfs-common netbase cifs-utils ca-certificates monit procps curl
+    apt install -y redis-server libvhdi-utils python3-minimal python3-jinja2 lvm2 nfs-common netbase cifs-utils ca-certificates monit procps curl ntfs-3g dmidecode
 
 # Install forever for starting/stopping Xen-Orchestra
 RUN npm install forever -g

--- a/run.sh
+++ b/run.sh
@@ -17,7 +17,7 @@ HTTP_PORT=${HTTP_PORT:-"80"}
 CERT_PATH=${CERT_PATH:-\'./temp-cert.pem\'}
 KEY_PATH=${KEY_PATH:-\'./temp-key.pem\'}
 
-/usr/bin/python2 -c 'import os
+/usr/bin/python3 -c 'import os
 import sys
 import jinja2
 sys.stdout.write(


### PR DESCRIPTION
See [XO installation docs](https://xen-orchestra.com/docs/installation.html#from-the-sources)

* update base image: node-18:bullseye
* python 2 -> python 3 in Dockerfile and run.sh
* added suggested packages from [#7095](https://github.com/vatesfr/xen-orchestra/issues/7095)

I just saw they suggest newer versions. So I tried and just made the minimal changes to make it build and run. Container logs show no difference to the docker hub image. 