### PR TITLE
Include v6 webui

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,11 +5,11 @@ on:
     - cron: "00 3 * * 6"
   push:
     paths-ignore:
-      - 'README.md'
-      - 'docker-compose.yml'
-      - '.github/**'
+      - "README.md"
+      - "docker-compose.yml"
+      - ".github/**"
     branches:
-      - 'master'
+      - "master"
   workflow_dispatch:
 
 jobs:
@@ -45,3 +45,15 @@ jobs:
           tags: |
             ronivay/xen-orchestra:latest
             ronivay/xen-orchestra:${{ env.XO_VERSION }}
+
+      - name: Build image and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          build-args: |
+            include_v6=true
+          tags: |
+            ronivay/xen-orchestra:latest-v6
+            ronivay/xen-orchestra:${{ env.XO_VERSION }}-v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,11 +5,11 @@ on:
     - cron: "00 3 * * 6"
   push:
     paths-ignore:
-      - "README.md"
-      - "docker-compose.yml"
-      - ".github/**"
+      - 'README.md'
+      - 'docker-compose.yml'
+      - '.github/**'
     branches:
-      - "master"
+      - 'master'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,15 +45,3 @@ jobs:
           tags: |
             ronivay/xen-orchestra:latest
             ronivay/xen-orchestra:${{ env.XO_VERSION }}
-
-      - name: Build image and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          platforms: linux/amd64
-          push: true
-          build-args: |
-            include_v6=true
-          tags: |
-            ronivay/xen-orchestra:latest-v6
-            ronivay/xen-orchestra:${{ env.XO_VERSION }}-v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # builder container
 FROM node:20-bullseye as build
 
+ARG include_v6
+
 # Install set of dependencies to support building Xen Orchestra
 RUN apt update && \
     apt install -y build-essential python3-minimal libpng-dev ca-certificates git fuse
@@ -13,7 +15,7 @@ RUN git clone -b master https://github.com/vatesfr/xen-orchestra /etc/xen-orches
 RUN cd /etc/xen-orchestra && \
     yarn config set network-timeout 200000 && \
     yarn && \
-    yarn build
+    [[ "$include_v6" == "true" ]] && yarn run turbo run build --filter @xen-orchestra/web || yarn build
 
 # Install plugins
 RUN find /etc/xen-orchestra/packages/ -maxdepth 1 -mindepth 1 -not -name "xo-server" -not -name "xo-web" -not -name "xo-server-cloud" -not -name "xo-server-test" -not -name "xo-server-test-plugin" -exec ln -s {} /etc/xen-orchestra/packages/xo-server/node_modules \;
@@ -21,7 +23,7 @@ RUN find /etc/xen-orchestra/packages/ -maxdepth 1 -mindepth 1 -not -name "xo-ser
 # Runner container
 FROM node:20-bullseye-slim
 
-MAINTAINER Roni Väyrynen <roni@vayrynen.info>
+LABEL org.opencontainers.image.authors="Roni Väyrynen <roni@vayrynen.info>"
 
 # Install set of dependencies for running Xen Orchestra
 RUN apt update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,10 @@ RUN git clone -b master https://github.com/vatesfr/xen-orchestra /etc/xen-orches
 
 # Run build tasks against sources
 # Docker buildx QEMU arm64 emulation is slow, so we set timeout for yarn
-RUN cd /etc/xen-orchestra && \
-    yarn config set network-timeout 200000 && \
-    yarn && \
-    [[ "$include_v6" == "true" ]] && yarn run turbo run build --filter @xen-orchestra/web || yarn build
+WORKDIR /etc/xen-orchestra
+RUN yarn config set network-timeout 200000 && yarn && yarn build
+
+RUN [ "$include_v6" = "true" ] && (yarn run turbo run build --filter @xen-orchestra/web || { echo "v6 build failed"; exit 1; }) || echo "v6 build skipped"
 
 # Install plugins
 RUN find /etc/xen-orchestra/packages/ -maxdepth 1 -mindepth 1 -not -name "xo-server" -not -name "xo-web" -not -name "xo-server-cloud" -not -name "xo-server-test" -not -name "xo-server-test-plugin" -exec ln -s {} /etc/xen-orchestra/packages/xo-server/node_modules \;

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN git clone -b master https://github.com/vatesfr/xen-orchestra /etc/xen-orches
 WORKDIR /etc/xen-orchestra
 RUN yarn config set network-timeout 200000 && yarn && yarn build
 
-RUN [ "$include_v6" = "true" ] && (yarn run turbo run build --filter @xen-orchestra/web || { echo "v6 build failed"; exit 1; }) || echo "v6 build skipped"
+# Builds the v6 webui
+RUN yarn run turbo run build --filter @xen-orchestra/web
 
 # Install plugins
 RUN find /etc/xen-orchestra/packages/ -maxdepth 1 -mindepth 1 -not -name "xo-server" -not -name "xo-web" -not -name "xo-server-cloud" -not -name "xo-server-test" -not -name "xo-server-test-plugin" -exec ln -s {} /etc/xen-orchestra/packages/xo-server/node_modules \;

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 # builder container
 FROM node:20-bullseye as build
 
-ARG include_v6
-
 # Install set of dependencies to support building Xen Orchestra
 RUN apt update && \
     apt install -y build-essential python3-minimal libpng-dev ca-certificates git fuse


### PR DESCRIPTION
- Replaces deprecated `MAINTANER` https://docs.docker.com/reference/dockerfile/#maintainer-deprecated with LABEL
- Adds an `ARG` for including `v6` 
- Adds an extra step on the pipeline to publish `-v6` suffixed tags for the image

I did successfully built the Dockerfile.
And successfully run it and been able to access both the original UI and the `/v6` ui.