### PR TITLE
feat: Bump node to 22 and use bookworm image variants

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # builder container
-FROM node:20-bullseye as build
+FROM node:22-bookworm as build
 
 # Install set of dependencies to support building Xen Orchestra
 RUN apt update && \
@@ -21,7 +21,7 @@ RUN yarn config set network-timeout 200000 && yarn && yarn build
 RUN find /etc/xen-orchestra/packages/ -maxdepth 1 -mindepth 1 -not -name "xo-server" -not -name "xo-web" -not -name "xo-server-cloud" -not -name "xo-server-test" -not -name "xo-server-test-plugin" -exec ln -s {} /etc/xen-orchestra/packages/xo-server/node_modules \;
 
 # Runner container
-FROM node:20-bullseye-slim
+FROM node:22-bookworm-slim
 
 LABEL org.opencontainers.image.authors="Roni Väyrynen <roni@vayrynen.info>"
 


### PR DESCRIPTION
Official XOA uses Debian 12 as their base OS.
By changing the "-bullseye" node image suffix to "-bookworm" we make sure that we use Debian 12 image as base aswell.

Also official Xen Orchestra documentation states to use current LTS release of node for building.
By bumping 20 to 22 in the node base images we make sure to use the latest LTS variant.

After applying the change the ronivay/xen-orchestra image is also more aligned with an installation resulting from XenOrchestraInstallerUpdater.