### PR TITLE
fix: use uppercase AS in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # builder container
-FROM node:22-bookworm as build
+FROM node:22-bookworm AS build
 
 # Install set of dependencies to support building Xen Orchestra
 RUN apt update && \


### PR DESCRIPTION
Building with Docker Desktop 4.44.3 (Engine 28.x) fails due to stricter keyword casing:

    Warning: FromAsCasing: 'as' and 'FROM' keywords' casing do not match
