### PR TITLE
Bump node js from 22 to 24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Xen Orchestra builder container
-FROM node:22-trixie as xo-build
+FROM node:24-trixie as xo-build
 
 # Install set of dependencies to support building Xen Orchestra
 RUN apt update && \
@@ -51,7 +51,7 @@ RUN autoreconf -i && \
     make install DESTDIR=/opt/stage/nbdkit
 
 # Runner container
-FROM node:22-trixie-slim
+FROM node:24-trixie-slim
 
 LABEL org.opencontainers.image.authors="Roni Väyrynen <roni@vayrynen.info>"
 


### PR DESCRIPTION
* Xen Orchestra documentation recommends to use latest LTS release of node js
* node js 24 has become the new LTS
* Some uers of Xen Orchestra reported in the forums that node js 24 is working with this software