### PR TITLE
re-enable v6 builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Xen Orchestra builder container
-FROM node:24-trixie as xo-build
+FROM node:24-trixie AS xo-build
 
 # Install set of dependencies to support building Xen Orchestra
 RUN apt update && \
@@ -15,13 +15,13 @@ RUN yarn config set network-timeout 200000 && yarn && yarn build
 
 # Builds the v6 webui
 # Disabled for now: https://github.com/ronivay/xen-orchestra-docker/issues/54
-#RUN yarn run turbo run build --filter @xen-orchestra/web
+RUN yarn run turbo run build --filter @xen-orchestra/web
 
 # Install plugins
 RUN find /etc/xen-orchestra/packages/ -maxdepth 1 -mindepth 1 -not -name "xo-server" -not -name "xo-web" -not -name "xo-server-cloud" -not -name "xo-server-test" -not -name "xo-server-test-plugin" -exec ln -s {} /etc/xen-orchestra/packages/xo-server/node_modules \;
 
 # libnbd / nbdkit builder container
-FROM debian:trixie as nbd-build
+FROM debian:trixie AS nbd-build
 
 # Install set of dependencies for building libnbd and nbdkit
 RUN apt update && \


### PR DESCRIPTION
```sh
❯ docker build . --platform linux/amd64
[+] Building 591.1s (36/36) FINISHED                                         docker:desktop-linux
 => [internal] load build definition from Dockerfile                                         0.0s
 => => transferring dockerfile: 3.44kB                                                       0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)               0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 24)              0.0s
 => [internal] load metadata for docker.io/library/node:24-trixie-slim                       0.2s
 => [internal] load metadata for docker.io/library/node:24-trixie                            0.2s
 => [internal] load metadata for docker.io/library/debian:trixie                             0.2s
 => [internal] load .dockerignore                                                            0.0s
 => => transferring context: 2B                                                              0.0s
 => [xo-build 1/7] FROM docker.io/library/node:24-trixie@sha256:1501d5fd51032aa10701a7dcc9  13.1s
 => => resolve docker.io/library/node:24-trixie@sha256:1501d5fd51032aa10701a7dcc9e6c72ab1e6  0.0s
 => => sha256:adfc1be7a9a2012907df978a794ad7b52773cbae7febf19592f8cdf55c 57.92MB / 57.92MB  12.4s
 => => sha256:7c40a3faff76845154c32b7b35d5535b201d3bd04f94a0c408f8e98f9 235.98MB / 235.98MB  2.8s
 => => extracting sha256:7c40a3faff76845154c32b7b35d5535b201d3bd04f94a0c408f8e98f9ed98ad6    2.0s
 => => extracting sha256:edeb656bc910bbe6fefcaedd87ac0bcb5079d3a79ee05d2537da3dd38b5dd2df    0.0s
 => => extracting sha256:adfc1be7a9a2012907df978a794ad7b52773cbae7febf19592f8cdf55c3d7ef3    0.6s
 => => extracting sha256:e44c3ebc0df7821adcf81bd7766616c4fbbe2f8c71cf9f510edbaf23044e0e8f    0.0s
 => => extracting sha256:0a0223fec36d58e07fa3a76859bf51fc9bc72c737ea03cfb9dc00ecd2345784a    0.0s
 => [internal] load build context                                                            0.0s
 => => transferring context: 167B                                                            0.0s
 => CACHED [nbd-build 1/7] FROM docker.io/library/debian:trixie@sha256:8f6a88feef3ed01a300d  0.0s
 => => resolve docker.io/library/debian:trixie@sha256:8f6a88feef3ed01a300dafb87f208977f39dc  0.0s
 => CACHED [stage-2  1/15] FROM docker.io/library/node:24-trixie-slim@sha256:fcdfd7bcd8f641  0.0s
 => => resolve docker.io/library/node:24-trixie-slim@sha256:fcdfd7bcd8f641c8c76a8950343c739  0.0s
 => [nbd-build 2/7] RUN apt update &&     apt install -y git dh-autoreconf pkg-config mak  142.1s
 => [stage-2  2/15] RUN apt update &&     apt install -y redis-server libvhdi-utils libxml  68.4s
 => [xo-build 2/7] RUN apt update &&     apt install -y build-essential python3-minimal lib  4.8s
 => [xo-build 3/7] RUN git clone -b master https://github.com/vatesfr/xen-orchestra /etc/x  52.8s
 => [stage-2  3/15] RUN npm install forever -g                                               6.8s
 => [xo-build 4/7] WORKDIR /etc/xen-orchestra                                                0.0s
 => [xo-build 5/7] RUN yarn config set network-timeout 200000 && yarn && yarn build        138.3s
 => [nbd-build 3/7] RUN git clone --depth 1 --branch "v1.23.4" "https://gitlab.com/nbdkit/l  5.1s
 => [nbd-build 4/7] WORKDIR /tmp/libnbd                                                      0.0s
 => [nbd-build 5/7] RUN autoreconf -i &&     ./configure --prefix=/usr/local &&     make   131.3s
 => [xo-build 6/7] RUN yarn run turbo run build --filter @xen-orchestra/web                 18.8s
 => [xo-build 7/7] RUN find /etc/xen-orchestra/packages/ -maxdepth 1 -mindepth 1 -not -name  0.5s
 => [stage-2  4/15] COPY --from=xo-build /etc/xen-orchestra /etc/xen-orchestra               3.3s
 => [nbd-build 6/7] WORKDIR /tmp/nbdkit                                                      0.0s
 => [nbd-build 7/7] RUN autoreconf -i &&     ./configure --prefix=/usr/local &&     make   288.9s
 => [stage-2  5/15] COPY --from=nbd-build /opt/stage/libnbd/usr/local /usr/local             0.3s
 => [stage-2  6/15] COPY --from=nbd-build /opt/stage/nbdkit/usr/local /usr/local             0.0s
 => [stage-2  7/15] RUN ldconfig                                                             0.1s
 => [stage-2  8/15] RUN ln -sf /proc/1/fd/1 /var/log/redis/redis-server.log &&     ln -sf /  0.1s
 => [stage-2  9/15] ADD healthcheck.sh /healthcheck.sh                                       0.0s
 => [stage-2 10/15] RUN chmod +x /healthcheck.sh                                             0.1s
 => [stage-2 11/15] ADD conf/xo-server.toml.j2 /xo-server.toml.j2                            0.0s
 => [stage-2 12/15] ADD conf/monit-services /etc/monit/conf.d/services                       0.0s
 => [stage-2 13/15] ADD run.sh /run.sh                                                       0.0s
 => [stage-2 14/15] RUN chmod +x /run.sh                                                     0.1s
 => [stage-2 15/15] WORKDIR /etc/xen-orchestra/packages/xo-server                            0.0s
 => exporting to image                                                                      22.3s
 => => exporting layers                                                                     22.3s
 => => exporting manifest sha256:a39c6b3d837410cd67af795355d57a5cc6d95958d9bd5176d9ff1131e5  0.0s
 => => exporting config sha256:46737d7d37def8495ead6a77cfd6840c56ec57a8e060be53ca80f4eb2bfc  0.0s
 => => exporting attestation manifest sha256:94a7216087f5e34fc21d5ea12e35e7111113adce3f8c51  0.0s
 => => exporting manifest list sha256:ffb475754df3a5779b9539e946ba972ec710b940cc584175c80f3  0.0s
 => => naming to moby-dangling@sha256:ffb475754df3a5779b9539e946ba972ec710b940cc584175c80f3  0.0s

 2 warnings found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 24)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/sss8n886r1tuqcfsjkbohe5u1

What's next:
    View a summary of image vulnerabilities and recommendations → docker scout quickview
```